### PR TITLE
73: Disabled user interaction for focus rectangle.

### DIFF
--- a/Seed-WeScan.podspec
+++ b/Seed-WeScan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "Seed-WeScan"
-  s.version           = "1.5.0-seed.0"
+  s.version           = "1.5.0-seed.1"
   s.summary           = "Document Scanning Made Easy for iOS"
   s.description       = "WeScan makes it easy to add scanning functionalities to your iOS app! It\'s modelled after UIImagePickerController, which makes it a breeze to use."
   s.homepage          = "https://github.com/seedco/WeScan"

--- a/WeScan/Scan/FocusRectangleView.swift
+++ b/WeScan/Scan/FocusRectangleView.swift
@@ -21,6 +21,7 @@ final class FocusRectangleView: UIView {
         layer.borderWidth = 2.0
         layer.cornerRadius = 6.0
         layer.borderColor = UIColor.yellow.cgColor
+        isUserInteractionEnabled = false
         
         // Here, we animate the rectangle from the `originalSize` to the `finalSize` by calculating the difference.
         UIView.animate(withDuration: 0.2, delay: 0.0, options: .curveEaseOut, animations: {


### PR DESCRIPTION
The focus rectangle was stealing user input from the capture button and was not serving any purpose. Now a photo can still be captured even if the focus rectangle intersects the capture button.